### PR TITLE
[Mod] add gazebo plugin package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-key del 7fa2af80 && \
 RUN apt-get -y update
 RUN apt-get -y install ros-melodic-rqt-*
 RUN apt-get -y install ros-melodic-hector-slam
-
+RUN apt-get -y install ros-melodic-gazebo-ros-pkgs ros-melodic-gazebo-ros-control
 # Do not edit from here
 
 # COPY ./docker-entrypoint.sh /docker-entrypoint.sh


### PR DESCRIPTION
ドロア開け,物体の再配置を行うためにはgazebo環境へアクセスできるパッケージが必要であるため